### PR TITLE
Fix: Participation vs. partecipation

### DIFF
--- a/src/EdpGithub/Api/Repos.php
+++ b/src/EdpGithub/Api/Repos.php
@@ -85,7 +85,7 @@ class Repos extends AbstractApi
      */
     public function partecipation($owner, $repo)
     {
-        return $this->get('repos/' . $owner . '/' . $repo . '/stats/partecipation');
+        return $this->get('repos/' . $owner . '/' . $repo . '/stats/participation');
     }
 
     /**

--- a/src/EdpGithub/Api/Repos.php
+++ b/src/EdpGithub/Api/Repos.php
@@ -78,14 +78,25 @@ class Repos extends AbstractApi
     }
 
     /**
-     * Get partecipation
+     * @param  string $owner
+     * @param  string $repo
+     * @return string
+     */
+    public function participation($owner, $repo)
+    {
+        return $this->get('repos/' . $owner . '/' . $repo . '/stats/participation');
+    }
+
+    /**
+     * @deprecated
+     *
      * @param  string $owner
      * @param  string $repo
      * @return string
      */
     public function partecipation($owner, $repo)
     {
-        return $this->get('repos/' . $owner . '/' . $repo . '/stats/participation');
+        return $this->participation($owner, $repo);
     }
 
     /**

--- a/test/EdpGithubTest/Api/ReposTest.php
+++ b/test/EdpGithubTest/Api/ReposTest.php
@@ -76,7 +76,7 @@ class ReposTest extends TestCase
     public function testPartecipation()
     {
         $expectedArray = array('id' => 1, 'name' => 'repo');
-        $client = $this->getClientMock('repos/owner/repo/stats/partecipation', $expectedArray);
+        $client = $this->getClientMock('repos/owner/repo/stats/participation', $expectedArray);
         $api = new Repos();
         $api->setClient($client);
         $result = $api->partecipation('owner', 'repo');

--- a/test/EdpGithubTest/Api/ReposTest.php
+++ b/test/EdpGithubTest/Api/ReposTest.php
@@ -73,6 +73,17 @@ class ReposTest extends TestCase
         $this->assertEquals($result, $expectedArray);
     }
 
+    public function testParticipation()
+    {
+        $expectedArray = array('id' => 1, 'name' => 'repo');
+        $client = $this->getClientMock('repos/owner/repo/stats/participation', $expectedArray);
+        $api = new Repos();
+        $api->setClient($client);
+        $result = $api->participation('owner', 'repo');
+
+        $this->assertEquals($result, $expectedArray);
+    }
+
     public function testPartecipation()
     {
         $expectedArray = array('id' => 1, 'name' => 'repo');


### PR DESCRIPTION
Instead of

```
GET /repos/:owner/:repo/stats/partecipation
```

it should be

```
GET /repos/:owner/:repo/stats/participation
```

See https://developer.github.com/v3/repos/statistics/#participation.