### PR TITLE
Fix: Parameters are unused

### DIFF
--- a/src/EdpGithub/Api/Markdown.php
+++ b/src/EdpGithub/Api/Markdown.php
@@ -10,11 +10,9 @@ class Markdown extends AbstractApi
      * @link http://developer.github.com/v3/markdown/
      *
      * @param  string $text
-     * @param  string $mode
-     * @param  string $context
      * @return string
      */
-    public function render($text, $mode = '', $context = '')
+    public function render($text)
     {
         $parameters = array(
                "text" => $text,


### PR DESCRIPTION
This PR

* [x] removes unused parameters from `Api\Markdown::render()`