### PR TITLE
Fix: Field is declared dynamically

### DIFF
--- a/src/EdpGithub/Api/AbstractApi.php
+++ b/src/EdpGithub/Api/AbstractApi.php
@@ -12,6 +12,11 @@ abstract class AbstractApi implements ServiceManagerAwareInterface
      */
     protected $client;
 
+    /**
+     * @var ServiceManager
+     */
+    private $serviceManager;
+
     protected $response;
 
     /**


### PR DESCRIPTION
This PR

* [x] adds a `serviceManager` property to `Api\AbstractApi` which is otherwise declared dynamically