### PR TITLE
Fix: Remove useless assignment

### DIFF
--- a/src/EdpGithub/Collection/RepositoryCollection.php
+++ b/src/EdpGithub/Collection/RepositoryCollection.php
@@ -96,7 +96,6 @@ class RepositoryCollection implements Iterator
 
     public function page($page)
     {
-        $this->parameters['per_page'] = $this->parameters['per_page'];
         $offsetStart = (($page-1) * $this->parameters['per_page']);
         $limit = $this->parameters['per_page'] -1;
         $elements = array();


### PR DESCRIPTION
This PR

* [x] removes a useless assignment